### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=RaceUp Team <info@raceup.it>
 maintainer=RaceUp Team <info@raceup.it>
 sentence=RaceUp core arduino library.
 paragraph=Arduino library to deal with most difficulties in our software issues. Deal with timers, CAN bus, Serial and so on.
+category=Other
 url=https://bitbucket.org/raceuped/raceup_ino_core
 architectures=avr


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library RaceUp_ino_core is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format